### PR TITLE
readme: changes after review

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,31 +46,31 @@ Share the new password with your team members. They can log in simultaneously fr
 
 ### 4. First Linux and ROS tests
 Once you have a terminal, let's refresh your linux skills. For example:
-`$ ls` shows the list of files and folders inside the current folder
-`$ cd folder_name` will change to folder_name
-`$ cd ..` will change one folder up
-`$ python3` will start an interactive python session, exit with `>>> exit()`
+`ls` shows the list of files and folders inside the current folder
+`cd folder_name` will change to folder_name
+`cd ..` will change one folder up
+`python3` will start an interactive python session, exit with `>>> exit()`
 <kbd>Tab</kbd> will autocomplete your command, very useful to prevent typos
 
 Let's test that ROS is already running. For example:
-`$ rosnode list` shows all ROS nodes that are currently running
-`$ rostopic list` shows all topics that exist
-`$ rostopic echo /topic_name` displays the messages being sent over `/topic_name` (e.g. `/arm/joint_states`)
+`rosnode list` shows all ROS nodes that are currently running
+`rostopic list` shows all topics that exist
+`rostopic echo /topic_name` displays the messages being sent over `/topic_name` (e.g. `/arm/joint_states`)
 <kbd>Ctrl</kbd>+<kbd>c</kbd> stops the last command
-`$ rosservice list` shows all available ROS services
+`rosservice list` shows all available ROS services
 
 ### 5. First robot motions
 Driving is controlled through the topic `/mobile_base_controller/cmd_vel`. Lift up the robot before trying, so that it doesn't drive off the table!
-`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
+`rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
 
 The robot keeps driving if the message keeps being repeated, with the `-r` (`--rate`) option:
-`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
+`rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
 
-Check the messages with `$ rostopic echo` in another terminal
+Check the messages with `rostopic echo` in another terminal
 
 ### 6. First launch of an additional ROS node: driving around!
 Driving is easier through keyboard teleoperation. This is available in a ROS node that is not currently running.
-`$ roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.
+`roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.
 Use the <kbd>x</kbd> and <kbd>c</kbd> keys to tone down linear velocity to `0.3` and angular velocity to `0.6`.
 Drive, and in a different terminal check out `rostopic echo /mobile_base_controller/cmd_vel`
 
@@ -96,7 +96,7 @@ Not all required software is on the robot yet. Before fixing that, you need to f
 
 ### 2. Connecting the robot to internet
 Make sure that there is a WIFI network that you have control over. For example, use your phone as a hotspot.
-`$ nmcli device wifi connect "SSID" password "PASSWORD"`   (use the correct SSID and PASSWORD) will connect your robot.
+`nmcli device wifi connect "SSID" password "PASSWORD"`   (use the correct SSID and PASSWORD) will connect your robot.
 
 As soon as you give this command, you lose the connection with the robot. To get back in touch:
 - Connect your laptop to the same WIFI network
@@ -109,8 +109,8 @@ If this does not work, you can change the WIFI using the web interface at https:
 
 #### 3.1 Clone this repository
 You are reading this on GitHub. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:
-`$ cd ~/mirte_ws/src`
-`$ git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd> to paste.
+`cd ~/mirte_ws/src`
+`git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd> to paste.
 
 #### 3.2 Clone the navigation repository
 Find the repository [MartijnWisse/mirte_navigation](https://github.com/MartijnWisse/mirte_navigation) on GitHub and clone that onto the robot as well.
@@ -120,26 +120,26 @@ Find the repository [MartijnWisse/mirte_navigation](https://github.com/MartijnWi
 
 #### 4.1 Compile
 Whenever you git clone a new package onto the robot, it needs to be compiled so that ROS can find and use it. For example:
-`$ cd ~/mirte_ws`
-`$ catkin build mirte_navigation`
-`$ catkin build mirte_workshop`
+`cd ~/mirte_ws`
+`catkin build mirte_navigation`
+`catkin build mirte_workshop`
 
 #### 4.2 Refresh Enironment
 Now, in any new terminal, ROS will know how to find the new folders and files. But not in terminals that already exist. To tell them, in each existing terminal you need to type:
-`$ source ~/mirte_ws/devel/setup.bash`
+`source ~/mirte_ws/devel/setup.bash`
 Alternatively, you can close the terminal(s) and open new ones.
 
 #### 4.3 Testing
 Let's test if it all works with the very underwhelming command
-`$ rosrun mirte_workshop mirte_keyboard.py`
+`rosrun mirte_workshop mirte_keyboard.py`
 
 ### 5. Launching mirte_workshop specific configuration
 When you turned on the robot, ROS was automatically started. However:
 - This is not exactly the right configuration for the workshop, and
 - It doesn't show screen output, so we don't know what is going on
 
-`$ sudo service mirte-ros stop`  will stop the invisible ROS instance.
-`$ roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.
+`sudo service mirte-ros stop`  will stop the invisible ROS instance.
+`roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.
 
 The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and <kbd>Ctrl</kbd>+<kbd>c</kbd> will stop ROS. Therefore, open new terminals to run additional commands.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Welcome to the Mirte Master workshop! Maybe, you have just assembled your own Mi
 ### 1. Preparations
 
 #### 1.1 Before switching on the robot, make sure that:
-- your Mirte Master has a fresh image containing its basic software, 
+- your Mirte Master has a fresh image containing its basic software,
 - the battery is sufficiently well charged,
-- the arm is pointing more or less upward.  
+- the arm is pointing more or less upward.
 *note: if the robot is already on, you cannot move the arm anymore. Don't try too hard, it might break.*
 
 #### 1.2 Switching Mirte on
@@ -17,21 +17,21 @@ Welcome to the Mirte Master workshop! Maybe, you have just assembled your own Mi
 - As long as the robot doesn't need to drive, keep it connected to the charger.
 
 #### 1.3 Battery Safety WARNING
-**Very important**: 
+**Very important**:
 The battery will break when over-discharged.
-Never let the battery percentage go below 10%. 
+Never let the battery percentage go below 10%.
 As long as ROS is running, it will check battery level and automatically shut down below 10%. Without ROS running, be extremely careful.
 
 ### 2. Connecting
 
 #### 2.1 Connect to the Wifi
-The rear display shows a WIFI network name, "mirte-XXXXXX". Connect to it with your laptop.  
-**Password**: mirte_mirte  
+The rear display shows a WIFI network name, "mirte-XXXXXX". Connect to it with your laptop.
+**Password**: mirte_mirte
 *note: you will lose internet, unless your laptop has a wired internet connection*
 
 #### 2.2 Navigate to the control interface
-Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"  
-**Login username**: mirte  
+Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"
+**Login username**: mirte
 **Password**: mirte_mirte
 
 You should see the vscode web editor, a powerful tool to program robots.  
@@ -39,61 +39,61 @@ In the bottom left, you can modify "Themes" --> "Color Theme" for better visibil
 
 ### 3. First login
 
-In the vscode web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.  
+In the vscode web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.
 *note: in Linux, you don't see what you type in the password field, for safety.*
 
 Share the new password with your team members. They can log in simultaneously from their own laptops.
 
 ### 4. First Linux and ROS tests
-Once you have a terminal, let's refresh your linux skills. For example:  
-`$ ls` shows the list of files and folders inside the current folder  
-`$ cd folder_name` will change to folder_name  
-`$ cd ..` will change one folder up  
-`$ python3` will start an interactive python session, exit with `>>> exit()`  
-`$ <tab>` will autocomplete your command, very useful to prevent typos  
+Once you have a terminal, let's refresh your linux skills. For example:
+`$ ls` shows the list of files and folders inside the current folder
+`$ cd folder_name` will change to folder_name
+`$ cd ..` will change one folder up
+`$ python3` will start an interactive python session, exit with `>>> exit()`
+`$ <tab>` will autocomplete your command, very useful to prevent typos
 
-Let's test that ROS is already running. For example:  
-`$ rosnode list` shows all ros nodes that are currently running  
-`$ rostopic list` shows all topics that exist  
-`$ rostopic echo /topic_name` displays the messages being sent over /topic_name (e.g. /arm/joint_states)  
-`$ ctrl-c` stops the last command  
-`$ rosservice list` shows all available ros services  
+Let's test that ROS is already running. For example:
+`$ rosnode list` shows all ros nodes that are currently running
+`$ rostopic list` shows all topics that exist
+`$ rostopic echo /topic_name` displays the messages being sent over /topic_name (e.g. /arm/joint_states)
+`$ ctrl-c` stops the last command
+`$ rosservice list` shows all available ros services
 
 ### 5. First robot motions
-Driving is controlled through the topic /mobile_base_controller/cmd_vel. Lift up the robot before trying, so that it doesn't drive off the table!   
-`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3  
+Driving is controlled through the topic /mobile_base_controller/cmd_vel. Lift up the robot before trying, so that it doesn't drive off the table!
+`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3
 
-The robot keeps driving if the message keeps being repeated, with the -r ('rate') option:  
-`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3  
+The robot keeps driving if the message keeps being repeated, with the -r ('rate') option:
+`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3
 
-Check the messages with `$ rostopic echo` in another terminal 
+Check the messages with `$ rostopic echo` in another terminal
 
 ### 6. First launch of an additional ROS node: driving around!
-Driving is easier through keyboard teleoperation. This is available in a ROS node that is not currently running.  
-`$ roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.  
-Use the x and c keys to tone down linear velocity to 0.3 and angular velocity to 0.6.  
+Driving is easier through keyboard teleoperation. This is available in a ROS node that is not currently running.
+`$ roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.
+Use the x and c keys to tone down linear velocity to 0.3 and angular velocity to 0.6.
 Drive, and in a different terminal check out `rostopic echo /mobile_base_controller/cmd_vel`
 
 ## Getting the workshop software on the robot
 ### 1. Folder structure
 Not all required software is on the robot yet. Before fixing that, you need to familiarize yourself with the overall folder structure. Browse folders in the left panel of vscode. The important part of the structure is:
 
-    /home/mirte  
-            └── mirte_ws  
-                    ├── build  
-                    ├── devel  
-                    └── src  
-                         ├── mirte_navigation    
-                         ├── mirte_workshop  
-                         ├── mirte_ros_packages  
-                         ├── ros_astra_camera  
-                         ├── rplidar_ros  
+    /home/mirte
+            └── mirte_ws
+                    ├── build
+                    ├── devel
+                    └── src
+                         ├── mirte_navigation
+                         ├── mirte_workshop
+                         ├── mirte_ros_packages
+                         ├── ros_astra_camera
+                         ├── rplidar_ros
 
-**The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from github, for which we need an internet connection.  
+**The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from github, for which we need an internet connection.
 
 ### 2. Connecting the robot to internet
-Make sure that there is a WIFI network that you have control over. For example, use your phone as a hotspot.   
-`$ nmcli device wifi connect "SSID" password "PASSWORD"`   (use the correct SSID and PASSWORD) will connect your robot.  
+Make sure that there is a WIFI network that you have control over. For example, use your phone as a hotspot.
+`$ nmcli device wifi connect "SSID" password "PASSWORD"`   (use the correct SSID and PASSWORD) will connect your robot.
 
 As soon as you give this command, you lose the connection with the robot. To get back in touch:
 - Connect your laptop to the same WIFI network
@@ -105,9 +105,9 @@ If this does not work, you can change the wifi using the web interface at https:
 ### 3. Cloning the github repositories
 
 #### 3.1 Clone this repository
-You are reading this on github. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:  
-`$ cd ~/mirte_ws/src`  
-`$ git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use ctrl+shift+v to paste. 
+You are reading this on github. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:
+`$ cd ~/mirte_ws/src`
+`$ git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use ctrl+shift+v to paste.
 
 #### 3.2 Clone the navigation repository
 Find the repository https://github.com/MartijnWisse/mirte_navigation on github and clone that onto the robot as well.
@@ -116,29 +116,29 @@ Find the repository https://github.com/MartijnWisse/mirte_navigation on github a
 ### 4. Compiling new packages
 
 #### 4.1 Compile
-Whenever you git clone a new package onto the robot, it needs to be compiled so that ROS can find and use it. For example:  
-`$ cd ~/mirte_ws`  
-`$ catkin build mirte_navigation`  
-`$ catkin build mirte_workshop`  
+Whenever you git clone a new package onto the robot, it needs to be compiled so that ROS can find and use it. For example:
+`$ cd ~/mirte_ws`
+`$ catkin build mirte_navigation`
+`$ catkin build mirte_workshop`
 
 #### 4.2 Refresh Enironment
-Now, in any new terminal, ROS will know how to find the new folders and files. But not in terminals that already exist. To tell them, in each existing terminal you need to type:  
-`$ source ~/mirte_ws/devel/setup.bash`  
+Now, in any new terminal, ROS will know how to find the new folders and files. But not in terminals that already exist. To tell them, in each existing terminal you need to type:
+`$ source ~/mirte_ws/devel/setup.bash`
 Alternatively, you can close the terminal(s) and open new ones.
 
 #### 4.3 Testing
-Let's test if it all works with the very underwhelming command  
-`$ rosrun mirte_workshop mirte_keyboard.py`  
+Let's test if it all works with the very underwhelming command
+`$ rosrun mirte_workshop mirte_keyboard.py`
 
 ### 5. Launching mirte_workshop specific configuration
-When you turned on the robot, ROS was automatically started. However:  
-- This is not exactly the right configuration for the workshop, and  
-- It doesn't show screen output, so we don't know what is going on  
+When you turned on the robot, ROS was automatically started. However:
+- This is not exactly the right configuration for the workshop, and
+- It doesn't show screen output, so we don't know what is going on
 
-`$ sudo service mirte-ros stop`  will stop the invisible ROS instance.  
-`$ roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.  
+`$ sudo service mirte-ros stop`  will stop the invisible ROS instance.
+`$ roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.
 
-The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and ctrl-c will stop ROS. Therefore, open new terminals to run additional commands. 
+The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and ctrl-c will stop ROS. Therefore, open new terminals to run additional commands.
 
 ## Get all the components ready
 Here are six workshop modules. The best way to work through them is to assign each module to a different team member.
@@ -156,7 +156,7 @@ Here are six workshop modules. The best way to work through them is to assign ea
 ### [6. Markers](markers.md)
 
 ## Make a delivery robot
-Put all the components together. You are free to create your own scenario. Here is one option:  
+Put all the components together. You are free to create your own scenario. Here is one option:
 - At the press of one key (e.g., '1'), drive to a location and deliver a package
 - At the press of another key, drive to a second location and deliver a package
 - At the press of a third key, go back to the home position (to collect more packages)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"
 **Login username**: mirte  
 **Password**: mirte_mirte
 
-You should see the vscode web editor, a powerfull tool to program robots.  
+You should see the vscode web editor, a powerful tool to program robots.  
 In the bottom left, you can modify "Themes" --> "Color Theme" for better visibility.
 
 ### 3. First login
@@ -61,10 +61,10 @@ Let's test that ROS is already running. For example:
 
 ### 5. First robot motions
 Driving is controlled through the topic /mobile_base_controller/cmd_vel. Lift up the robot before trying, so that it doesn't drive off the table!   
-`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the x value in 0.3  
+`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3  
 
 The robot keeps driving if the message keeps being repeated, with the -r ('rate') option:  
-`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the x value in 0.3  
+`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3  
 
 Check the messages with `$ rostopic echo` in another terminal 
 

--- a/README.md
+++ b/README.md
@@ -19,59 +19,94 @@ Welcome to the Mirte Master workshop! Maybe, you have just assembled your own Mi
 #### 1.3 Battery Safety WARNING
 **Very important**:
 The battery will break when over-discharged.
-Never let the battery percentage go below 10%.
+
+> [!WARNING]  
+> Never let the battery percentage go below 10%.
+
 As long as ROS is running, it will check battery level and automatically shut down below 10%. Without ROS running, be extremely careful.
 
 ### 2. Connecting
 
 #### 2.1 Connect to the Wifi
-The rear display shows a WIFI network name, `mirte-XXXXXX`. Connect to it with your laptop.
-**Password**: `mirte_mirte`
-*note: you will lose internet access, unless your laptop has another (fi: wired) internet connection*
+The rear display shows a WIFI network name, `mirte-XXXXXX`. Connect to it with your laptop (**Password**: `mirte_mirte`).
+
+> [!NOTE]  
+> You will lose internet access, unless your laptop has another (fi: wired) internet connection.
 
 #### 2.2 Navigate to the control interface
-Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"
-**Login username**: `mirte`
-**Password**: `mirte_mirte`
+Open a browser on your laptop and go to the website "http://192.168.42.1:8000"
+
+**Username**: `mirte`  
+**Password**: `mirte_mirte`  
 
 You should see the VS Code web editor, a powerful tool to program robots.
-In the bottom left, you can modify "Themes" --> "Color Theme" for better visibility.
+
+> [!TIP]  
+> In the bottom left, you can modify "Themes" --> "Color Theme" for better visibility.
 
 ### 3. First login
 
 In the VS Code web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.
-*note: in Linux, you don't see what you type in the password field, this is for improved security.*
+
+> [!NOTE]  
+> In Linux, you don't see what you type in the password field, this is for improved security.
 
 Share the new password with your team members. They can log in simultaneously from their own laptops.
 
 ### 4. First Linux and ROS tests
 Once you have a terminal, let's refresh your linux skills. For example:
-`ls` shows the list of files and folders inside the current folder
-`cd folder_name` will change to folder_name
-`cd ..` will change one folder up
-`python3` will start an interactive python session, exit with `>>> exit()`
-<kbd>Tab</kbd> will autocomplete your command, very useful to prevent typos
+
+| Command|  |
+|:-------|--|
+| `ls` | shows the list of files and folders inside the current folder |
+| `cd folder_name` | will change to folder_name |
+| `cd ..` | will change one folder up |
+| `python3` | will start an interactive python session, exit with `>>> exit()` |
+| <kbd>Tab</kbd> | will autocomplete your command, very useful to prevent typos |
 
 Let's test that ROS is already running. For example:
-`rosnode list` shows all ROS nodes that are currently running
-`rostopic list` shows all topics that exist
-`rostopic echo /topic_name` displays the messages being sent over `/topic_name` (e.g. `/arm/joint_states`)
-<kbd>Ctrl</kbd>+<kbd>c</kbd> stops the last command
-`rosservice list` shows all available ROS services
+
+| Command|  |
+|:-------|--|
+| `rosnode list` | shows all ROS nodes that are currently running |
+| `rostopic list` | shows all topics that exist |
+| `rostopic echo /topic_name` | displays the messages being sent over `/topic_name` (e.g. `/arm/joint_states`) |
+| <kbd>Ctrl</kbd>+<kbd>c</kbd> | stops the last command |
+| `rosservice list` | shows all available ROS services |
 
 ### 5. First robot motions
-Driving is controlled through the topic `/mobile_base_controller/cmd_vel`. Lift up the robot before trying, so that it doesn't drive off the table!
-`rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
+Driving is controlled through the topic `/mobile_base_controller/cmd_vel`.
 
-The robot keeps driving if the message keeps being repeated, with the `-r` (`--rate`) option:
-`rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
+> [!CAUTION]  
+> Lift up the robot before trying, so that it doesn't drive off the table!
 
-Check the messages with `rostopic echo` in another terminal
+Try the following command.
+After pressing <kbd>Tab</kbd> twice, change the `x` value to `0.3` and press <kbd>Enter</kbd> to publish the message:
+
+```bash
+rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>
+```
+
+Stop the publisher with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
+
+The robot keeps driving if the message keeps being repeated, with the `-r` (`--rate`) option.
+After pressing <kbd>Tab</kbd> twice, change the `x` value to `0.3` again and press <kbd>Enter</kbd> to publish the message:
+
+```bash
+rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>
+```
+
+Check the messages with `rostopic echo` in another terminal.
+
+Stop the publisher with <kbd>Ctrl</kbd>+<kbd>c</kbd>.
+
 
 ### 6. First launch of an additional ROS node: driving around!
 Driving is easier through keyboard teleoperation. This is available in a ROS node that is not currently running.
 `roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.
+
 Use the <kbd>x</kbd> and <kbd>c</kbd> keys to tone down linear velocity to `0.3` and angular velocity to `0.6`.
+
 Drive, and in a different terminal check out `rostopic echo /mobile_base_controller/cmd_vel`
 
 ## Getting the workshop software on the robot
@@ -79,24 +114,29 @@ Drive, and in a different terminal check out `rostopic echo /mobile_base_control
 Not all required software is on the robot yet. Before fixing that, you need to familiarize yourself with the overall folder structure. Browse folders in the left panel of VS Code. The important part of the structure is:
 
 ```
-/home
-└── mirte
-    └── mirte_ws
-        ├── build
-        ├── devel
-        └── src
-            ├── mirte_navigation
-            ├── mirte_workshop
-            ├── mirte_ros_packages
-            ├── ros_astra_camera
-            ├── rplidar_ros
+📁 /home
+└── 📁 mirte
+    └── 📁 mirte_ws
+        ├── 📁 build
+        ├── 📁 devel
+        └── 📁 src
+            ├── 📁 mirte_navigation
+            ├── 📁 mirte_workshop
+            ├── 📁 mirte_ros_packages
+            ├── 📁 ros_astra_camera
+            ├── 📁 rplidar_ros
 ```
 
 **The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from GitHub, for which we need an internet connection.
 
 ### 2. Connecting the robot to internet
 Make sure that there is a WIFI network that you have control over. For example, use your phone as a hotspot.
-`nmcli device wifi connect "SSID" password "PASSWORD"`   (use the correct SSID and PASSWORD) will connect your robot.
+
+The following command will connect your robot (use the correct SSID and PASSWORD):
+
+```bash
+nmcli device wifi connect "SSID" password "PASSWORD"
+```
 
 As soon as you give this command, you lose the connection with the robot. To get back in touch:
 - Connect your laptop to the same WIFI network
@@ -109,8 +149,14 @@ If this does not work, you can change the WIFI using the web interface at https:
 
 #### 3.1 Clone this repository
 You are reading this on GitHub. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:
-`cd ~/mirte_ws/src`
-`git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd> to paste.
+
+```bash
+cd ~/mirte_ws/src
+git clone <...>
+```
+
+Replace `<...>` with the https address of the repository. Paste it using a right mouse click, or use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>.
+
 
 #### 3.2 Clone the navigation repository
 Find the repository [MartijnWisse/mirte_navigation](https://github.com/MartijnWisse/mirte_navigation) on GitHub and clone that onto the robot as well.
@@ -120,26 +166,45 @@ Find the repository [MartijnWisse/mirte_navigation](https://github.com/MartijnWi
 
 #### 4.1 Compile
 Whenever you git clone a new package onto the robot, it needs to be compiled so that ROS can find and use it. For example:
-`cd ~/mirte_ws`
-`catkin build mirte_navigation`
-`catkin build mirte_workshop`
 
-#### 4.2 Refresh Enironment
+```bash
+cd ~/mirte_ws
+catkin build mirte_navigation
+catkin build mirte_workshop
+```
+
+#### 4.2 Refresh Environment
 Now, in any new terminal, ROS will know how to find the new folders and files. But not in terminals that already exist. To tell them, in each existing terminal you need to type:
-`source ~/mirte_ws/devel/setup.bash`
+
+```bash
+source ~/mirte_ws/devel/setup.bash
+```
+
 Alternatively, you can close the terminal(s) and open new ones.
 
 #### 4.3 Testing
 Let's test if it all works with the very underwhelming command
-`rosrun mirte_workshop mirte_keyboard.py`
+
+```bash
+rosrun mirte_workshop mirte_keyboard.py
+```
 
 ### 5. Launching mirte_workshop specific configuration
 When you turned on the robot, ROS was automatically started. However:
 - This is not exactly the right configuration for the workshop, and
 - It doesn't show screen output, so we don't know what is going on
 
-`sudo service mirte-ros stop`  will stop the invisible ROS instance.
-`roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.
+Stop the invisible ROS instance:
+
+```bash
+sudo service mirte-ros stop
+```
+
+Now start the right one with:
+
+```bash
+roslaunch mirte_workshop mirte_workshop.launch
+```
 
 The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and <kbd>Ctrl</kbd>+<kbd>c</kbd> will stop ROS. Therefore, open new terminals to run additional commands.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ As long as ROS is running, it will check battery level and automatically shut do
 #### 2.1 Connect to the Wifi
 The rear display shows a WIFI network name, `mirte-XXXXXX`. Connect to it with your laptop.
 **Password**: `mirte_mirte`
-*note: you will lose internet, unless your laptop has a wired internet connection*
+*note: you will lose internet access, unless your laptop has another (fi: wired) internet connection*
 
 #### 2.2 Navigate to the control interface
 Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"
@@ -40,7 +40,7 @@ In the bottom left, you can modify "Themes" --> "Color Theme" for better visibil
 ### 3. First login
 
 In the VS Code web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.
-*note: in Linux, you don't see what you type in the password field, for safety.*
+*note: in Linux, you don't see what you type in the password field, this is for improved security.*
 
 Share the new password with your team members. They can log in simultaneously from their own laptops.
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ As long as ROS is running, it will check battery level and automatically shut do
 ### 2. Connecting
 
 #### 2.1 Connect to the Wifi
-The rear display shows a WIFI network name, "mirte-XXXXXX". Connect to it with your laptop.
-**Password**: mirte_mirte
+The rear display shows a WIFI network name, `mirte-XXXXXX`. Connect to it with your laptop.
+**Password**: `mirte_mirte`
 *note: you will lose internet, unless your laptop has a wired internet connection*
 
 #### 2.2 Navigate to the control interface
 Open a browser on your laptop. Go to the website "http://192.168.42.1:8000"
-**Login username**: mirte
-**Password**: mirte_mirte
+**Login username**: `mirte`
+**Password**: `mirte_mirte`
 
-You should see the vscode web editor, a powerful tool to program robots.  
+You should see the VS Code web editor, a powerful tool to program robots.
 In the bottom left, you can modify "Themes" --> "Color Theme" for better visibility.
 
 ### 3. First login
 
-In the vscode web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.
+In the VS Code web editor, open a new terminal. You will be asked to choose a new password. After changing the password you may have to log in again.
 *note: in Linux, you don't see what you type in the password field, for safety.*
 
 Share the new password with your team members. They can log in simultaneously from their own laptops.
@@ -50,33 +50,33 @@ Once you have a terminal, let's refresh your linux skills. For example:
 `$ cd folder_name` will change to folder_name
 `$ cd ..` will change one folder up
 `$ python3` will start an interactive python session, exit with `>>> exit()`
-`$ <tab>` will autocomplete your command, very useful to prevent typos
+<kbd>Tab</kbd> will autocomplete your command, very useful to prevent typos
 
 Let's test that ROS is already running. For example:
-`$ rosnode list` shows all ros nodes that are currently running
+`$ rosnode list` shows all ROS nodes that are currently running
 `$ rostopic list` shows all topics that exist
-`$ rostopic echo /topic_name` displays the messages being sent over /topic_name (e.g. /arm/joint_states)
-`$ ctrl-c` stops the last command
-`$ rosservice list` shows all available ros services
+`$ rostopic echo /topic_name` displays the messages being sent over `/topic_name` (e.g. `/arm/joint_states`)
+<kbd>Ctrl</kbd>+<kbd>c</kbd> stops the last command
+`$ rosservice list` shows all available ROS services
 
 ### 5. First robot motions
-Driving is controlled through the topic /mobile_base_controller/cmd_vel. Lift up the robot before trying, so that it doesn't drive off the table!
-`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3
+Driving is controlled through the topic `/mobile_base_controller/cmd_vel`. Lift up the robot before trying, so that it doesn't drive off the table!
+`$ rostopic pub /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
 
-The robot keeps driving if the message keeps being repeated, with the -r ('rate') option:
-`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the x value to 0.3
+The robot keeps driving if the message keeps being repeated, with the `-r` (`--rate`) option:
+`$ rostopic pub -r 10 /mobile_base_controller/cmd_vel <tab> <tab>` change the `x` value to `0.3`
 
 Check the messages with `$ rostopic echo` in another terminal
 
 ### 6. First launch of an additional ROS node: driving around!
 Driving is easier through keyboard teleoperation. This is available in a ROS node that is not currently running.
 `$ roslaunch mirte_teleop teleopkey.launch` will start keyboard teleoperation.
-Use the x and c keys to tone down linear velocity to 0.3 and angular velocity to 0.6.
+Use the <kbd>x</kbd> and <kbd>c</kbd> keys to tone down linear velocity to `0.3` and angular velocity to `0.6`.
 Drive, and in a different terminal check out `rostopic echo /mobile_base_controller/cmd_vel`
 
 ## Getting the workshop software on the robot
 ### 1. Folder structure
-Not all required software is on the robot yet. Before fixing that, you need to familiarize yourself with the overall folder structure. Browse folders in the left panel of vscode. The important part of the structure is:
+Not all required software is on the robot yet. Before fixing that, you need to familiarize yourself with the overall folder structure. Browse folders in the left panel of VS Code. The important part of the structure is:
 
     /home/mirte
             └── mirte_ws
@@ -89,7 +89,7 @@ Not all required software is on the robot yet. Before fixing that, you need to f
                          ├── ros_astra_camera
                          ├── rplidar_ros
 
-**The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from github, for which we need an internet connection.
+**The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from GitHub, for which we need an internet connection.
 
 ### 2. Connecting the robot to internet
 Make sure that there is a WIFI network that you have control over. For example, use your phone as a hotspot.
@@ -100,17 +100,17 @@ As soon as you give this command, you lose the connection with the robot. To get
 - Find the robot's IP address from your phone hotspot
 - Use this IP address in the browser
 
-If this does not work, you can change the wifi using the web interface at https://192.168.42.1
+If this does not work, you can change the WIFI using the web interface at https://192.168.42.1
 
-### 3. Cloning the github repositories
+### 3. Cloning the GitHub repositories
 
 #### 3.1 Clone this repository
-You are reading this on github. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:
+You are reading this on GitHub. If you scroll up, there is a list of folders and files that together are the package `mirte_workshop`. With the green button that says `<> Code`, copy the https address of the repository. Then use the following commands to copy it onto your robot:
 `$ cd ~/mirte_ws/src`
-`$ git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use ctrl+shift+v to paste.
+`$ git clone ...`  paste the copied https address in place of the dots. Use the mouse right click, or use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd> to paste.
 
 #### 3.2 Clone the navigation repository
-Find the repository https://github.com/MartijnWisse/mirte_navigation on github and clone that onto the robot as well.
+Find the repository [MartijnWisse/mirte_navigation](https://github.com/MartijnWisse/mirte_navigation) on GitHub and clone that onto the robot as well.
 
 
 ### 4. Compiling new packages
@@ -138,7 +138,7 @@ When you turned on the robot, ROS was automatically started. However:
 `$ sudo service mirte-ros stop`  will stop the invisible ROS instance.
 `$ roslaunch mirte_workshop mirte_workshop.launch`  will start the right one.
 
-The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and ctrl-c will stop ROS. Therefore, open new terminals to run additional commands.
+The screen will show which nodes are being started. It will also show error messages, if any. Once launched, you can no longer use this terminal, and <kbd>Ctrl</kbd>+<kbd>c</kbd> will stop ROS. Therefore, open new terminals to run additional commands.
 
 ## Get all the components ready
 Here are six workshop modules. The best way to work through them is to assign each module to a different team member.

--- a/README.md
+++ b/README.md
@@ -78,16 +78,19 @@ Drive, and in a different terminal check out `rostopic echo /mobile_base_control
 ### 1. Folder structure
 Not all required software is on the robot yet. Before fixing that, you need to familiarize yourself with the overall folder structure. Browse folders in the left panel of VS Code. The important part of the structure is:
 
-    /home/mirte
-            └── mirte_ws
-                    ├── build
-                    ├── devel
-                    └── src
-                         ├── mirte_navigation
-                         ├── mirte_workshop
-                         ├── mirte_ros_packages
-                         ├── ros_astra_camera
-                         ├── rplidar_ros
+```
+/home
+└── mirte
+    └── mirte_ws
+        ├── build
+        ├── devel
+        └── src
+            ├── mirte_navigation
+            ├── mirte_workshop
+            ├── mirte_ros_packages
+            ├── ros_astra_camera
+            ├── rplidar_ros
+```
 
 **The packages `mirte_navigation` and `mirte_workshop` don't exist yet**. We need to get them from GitHub, for which we need an internet connection.
 


### PR DESCRIPTION
These are all *suggestions*, although some commits fix typos.

Others mostly change style or formatting.

Rendered version: [here](https://github.com/gavanderhoorn/mirte_workshop/blob/d3eb663cdaddc60f86402ce6c0343424a6e493fd/README.md).

I've removed most of the forced line-breaks (double space at EOL), as it'd be better to let the Markdown renderer generate those I believe.

---

Edit: I've not changed any of the other Markdown files in this repository. Similar changes could be made to them (such as using [fenced code blocks with highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks) for the Python code).
