### PR TITLE
Use fenced code blocks with highlighting

### DIFF
--- a/arm_and_gripper.md
+++ b/arm_and_gripper.md
@@ -15,48 +15,50 @@ To make the robot autonomous, the arm commands should come from code rather than
 
 Copy the following content in the file:  
 
-    #!/usr/bin/env python3
+```python
+#!/usr/bin/env python3
 
-    # ---- Load libraries ----
-    # load the library with ROS functionality for Python
-    import rospy      
-    # load the specific message format required for joint commands
-    from std_msgs.msg import Float64MultiArray   
+# ---- Load libraries ----
+# load the library with ROS functionality for Python
+import rospy
+# load the specific message format required for joint commands
+from std_msgs.msg import Float64MultiArray
 
-    # ---- Initialize ----
-    # start a new ROS node
-    rospy.init_node('arm_simple_script')  
-    # provide on-screen information
-    rospy.loginfo('The arm_simple_script has started!')  
-    # create the publisher, tell it which topic to publish on
-    arm_command_publisher = rospy.Publisher('/arm/joint_position_controller/command', Float64MultiArray, queue_size=10)
-    # give the publisher some time to get ready
-    rospy.sleep(1)  
-
-
-    # ---- Make the first motion ----
-    # define the variable type
-    position1 = Float64MultiArray()
-    # define the variable values
-    position1.data = [0, 0, 0, 0]  
-    # publish the command
-    arm_command_publisher.publish(position1)
-    # provide on-screen information
-    rospy.loginfo('Moving to position 1')
+# ---- Initialize ----
+# start a new ROS node
+rospy.init_node('arm_simple_script')
+# provide on-screen information
+rospy.loginfo('The arm_simple_script has started!')
+# create the publisher, tell it which topic to publish on
+arm_command_publisher = rospy.Publisher('/arm/joint_position_controller/command', Float64MultiArray, queue_size=10)
+# give the publisher some time to get ready
+rospy.sleep(1)
 
 
-    # give the robot some time to execute the first motion
-    rospy.sleep(1)
+# ---- Make the first motion ----
+# define the variable type
+position1 = Float64MultiArray()
+# define the variable values
+position1.data = [0, 0, 0, 0]
+# publish the command
+arm_command_publisher.publish(position1)
+# provide on-screen information
+rospy.loginfo('Moving to position 1')
 
 
-    # ---- Make the second motion ----
-    position2 = Float64MultiArray()
-    position2.data = [1, 0, 0, 0]
-    arm_command_publisher.publish(position2)
-    rospy.loginfo('Moving to position 2')
+# give the robot some time to execute the first motion
+rospy.sleep(1)
 
 
-    # The end of the file is reached, so it stops
+# ---- Make the second motion ----
+position2 = Float64MultiArray()
+position2.data = [1, 0, 0, 0]
+arm_command_publisher.publish(position2)
+rospy.loginfo('Moving to position 2')
+
+
+# The end of the file is reached, so it stops
+```
 
 Save the file, move to the script directory and test if it works with:
 ```

--- a/keyboard_control.md
+++ b/keyboard_control.md
@@ -14,25 +14,33 @@ Instead of having to type this over and over again (even though arrow-up makes t
 
 In the python file, the character 'q' is singled out for extra functionality. We will do the same for the character '1'. After the lines
 
-    if key == 'q':
-        rospy.loginfo("Quitting...")
-        break
+```python
+if key == 'q':
+    rospy.loginfo("Quitting...")
+    break
+```
 
 add the lines
 
-    elif key == '1':                            
-        rospy.loginfo(f"1 = arm to position 1")       
-        position1 = Float64MultiArray()        
-        position1.data = [0,0.5,0,0]             
-        arm_command_publisher.publish(position1)
+```python
+elif key == '1':
+    rospy.loginfo(f"1 = arm to position 1")
+    position1 = Float64MultiArray()
+    position1.data = [0,0.5,0,0]
+    arm_command_publisher.publish(position1)
+```
 
 This is not enough yet. The file needs to be told on which topic to publish. After the line that creates the /key_press publisher, add
 
-    arm_command_publisher = rospy.Publisher('/arm/joint_position_controller/command', Float64MultiArray, queue_size=1)  
+```python
+arm_command_publisher = rospy.Publisher('/arm/joint_position_controller/command', Float64MultiArray, queue_size=1)
+```
 
 This command requires that the Python file knows what data type Float64MultiArray is, so in the first lines of the file add  
 
-    from std_msgs.msg import Float64MultiArray 
+```python
+from std_msgs.msg import Float64MultiArray
+```
 
 To test your skills, you can add a few more positions. Or you could try to publish on /mobile_base_controller/cmd_vel. Or, for example, you could use the key 'y' to increase the value of a variable that you could call `shoulder_angle`, the key 'h' to decrease the value, and then publish [0, shoulder_angle, 0, 0], to move the shoulder anywhere you want.
 
@@ -44,17 +52,23 @@ Our file can also be useful to quickly test (new) ROS services. Instead of the c
 
 To tell the file mirte_keyboard.py which rosservice to address, add the following line
 
-    set_gripper_angle = rospy.ServiceProxy('/mirte/set_servoGripper_servo_angle', SetServoAngle)
+```python
+set_gripper_angle = rospy.ServiceProxy('/mirte/set_servoGripper_servo_angle', SetServoAngle)
+```
 
 This requires the following addition in the first few lines of the file:
 
-    from mirte_msgs.srv import SetServoAngle
+```python
+from mirte_msgs.srv import SetServoAngle
+```
 
 The service is now ready to be used when a specific key is pressed, let's use 'g' by adding at the appropriate place:
 
-    elif key == 'g':                            
-        rospy.loginfo(f"g = gripper servo to angle 0.2")       
-        set_gripper_angle(0.2)
+```python
+elif key == 'g':
+    rospy.loginfo(f"g = gripper servo to angle 0.2")
+    set_gripper_angle(0.2)
+```
 
 ## Testing command-line commands
 Any other command-line command can also be tested through the press of a key. For example, a team member will save maps with:  
@@ -62,9 +76,11 @@ Any other command-line command can also be tested through the press of a key. Fo
 
 We will let the character 'm' execute this command-line command. At the appropriate place, add to mirte_keyboard.py:  
 
-    elif key == 'm':         
-        rospy.loginfo(f"m = save map (replaces previous map)") 
-        os.system(f"rosrun map_server map_saver -f /home/mirte/mirte_ws/src/mirte_workshop/maps/default") 
+```python
+elif key == 'm':
+    rospy.loginfo(f"m = save map (replaces previous map)")
+    os.system(f"rosrun map_server map_saver -f /home/mirte/mirte_ws/src/mirte_workshop/maps/default")
+```
 
 ## Assist other team members 
 Check with your team members which topics, services, or other commands need to be tested and make mirte_keyboard.py useful for them. If there are too many key bindings to remember, let the python file print the available keys and their meanings on screen using the `rospy.loginfo('text goes here')` command. Likely examples to integrate:

--- a/launch_files.md
+++ b/launch_files.md
@@ -11,9 +11,11 @@ The command structure is roslaunch package_name file_name. It cleverly knows to 
 In the folder ~/mirte_ws/src/mirte_workshop/launch, create a new file and call it 'arm_and_gripper.launch'  
 Copy the following code in it:
 
-    <launch>
-        <node pkg="mirte_workshop" name="arm_server" type="arm_server.py" output="screen"/>
-    </launch>
+```xml
+<launch>
+    <node pkg="mirte_workshop" name="arm_server" type="arm_server.py" output="screen"/>
+</launch>
+```
 
 Save the file and test it with `$ roslaunch mirte_workshop arm_and_gripper.launch`  
 Now add the gripper_server.py node to the launch file and test it. Make sure that nodes are not started twice, note that other team members may start nodes from their computer.  
@@ -28,7 +30,9 @@ By the way, the rosrun command is still better than `$ python3 arm_server.py`. F
 ## Include other launch files
 Code that works well, does not need to be started separately; you can have it launch together with all the other nodes. Just leave your new arm_and_gripper.launch file as it is, and add the following line to mirte_workshop.launch
 
-    <include file="$(find mirte_workshop)/launch/arm_and_gripper.launch"/>
+```xml
+<include file="$(find mirte_workshop)/launch/arm_and_gripper.launch"/>
+```
 
 Or, vice versa, you could include the mirte_workshop.launch file in your own.
 
@@ -36,7 +40,9 @@ Or, vice versa, you could include the mirte_workshop.launch file in your own.
 For an even faster start, you can create an 'alias' in Linux. 
 Open the file `~/.bashrc` in the editor. Add the following line at the bottom of the file:  
 
-    alias go='roslaunch mirte_workshop mirte_workshop.launch'
+```bash
+alias go='roslaunch mirte_workshop mirte_workshop.launch'
+```
 
 Save the file. All new terminals will now execute the roslaunch command if you type `$ go`, but existing terminals won't, unless you `$ source ~/.bashrc` 
 

--- a/navigation.md
+++ b/navigation.md
@@ -23,7 +23,9 @@ Again, you need RVIZ to see whether it works. In addition to showing the map, yo
 ## Using a custom map name
 If you wish to use a different map name, use your custom map name in the map_saver command. To use this map for navigation, open the file `~/mirte_ws/src/mirte_navigation/launch/amcl_demo.launch` and change the map name in the line 
 
-    <arg name="map_file" default="$(find mirte_workshop)/maps/default.yaml"/>
+```xml
+<arg name="map_file" default="$(find mirte_workshop)/maps/default.yaml"/>
+```
 
 ## Navigating
 A quick and satisfying way to test navigation is to click "2D Nav Goal" (pink arrow) in RVIZ. Pay attention to the terminal from which amcl_demo was launched.  


### PR DESCRIPTION
This makes embedded code / launch files (and snippets) easier to read.

Example rendered version: [here](https://github.com/gavanderhoorn/mirte_workshop/blob/d9567f7bf6107de134862d04bec4d83f355ec1eb/arm_and_gripper.md) (note the highlighting of the Python code).

No other changes to any of these files.
